### PR TITLE
return self.__class__ rather than RowColMap

### DIFF
--- a/gridded_cayley_permutations/row_col_map.py
+++ b/gridded_cayley_permutations/row_col_map.py
@@ -145,7 +145,7 @@ class RowColMap:
             new_col_map[col_index + i] = original_col + i
         for i in range(number_of_rows):
             new_row_map[row_index + i] = original_row + i
-        return RowColMap(new_col_map, new_row_map)
+        return self.__class__(new_col_map, new_row_map)
 
     def preimages_of_row(self, row: int) -> tuple[int, ...]:
         """Return the preimages of all values in the row."""
@@ -223,7 +223,7 @@ class RowColMap:
             new_col_map[index] = self.col_map[index]
         for index in row_values:
             new_row_map[index] = self.row_map[index]
-        return RowColMap(new_col_map, new_row_map)
+        return self.__class__(new_col_map, new_row_map)
 
     def standardise_map(self) -> "RowColMap":
         """

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="cayley_perms",
     version="1.0",
     description="A module for using Cayley permutations.",
-    author="Reid Acton, Christian Bean, and Abigail Ollson",
+    author="Reed Acton, Christian Bean, and Abigail Ollson",
     author_email="c.n.bean@keele.ac.uk",
     packages=[
         "cayley_permutations",


### PR DESCRIPTION
And fixed spelling of Reed's name

I think this is enough, should the typing be changed too (eg line 127), or the instance on line 122?