### PR TITLE
Row Col Split

### DIFF
--- a/gridded_cayley_permutations/tilings.py
+++ b/gridded_cayley_permutations/tilings.py
@@ -428,8 +428,13 @@ class Tiling(CombinatorialClass):
                 ]
             )
         )
+        new_dimensions = list(self.dimensions)
+        new_dimensions[direction] += 1
         new_tiling = Tiling(
-            new_obstructions, new_requirements, self.dimensions, simplify=False
+            new_obstructions,
+            new_requirements,
+            (new_dimensions[0], new_dimensions[1]),
+            simplify=False,
         )
         return new_tiling
 

--- a/gridded_cayley_permutations/tilings.py
+++ b/gridded_cayley_permutations/tilings.py
@@ -428,7 +428,9 @@ class Tiling(CombinatorialClass):
                 ]
             )
         )
-        new_tiling = Tiling(new_obstructions, new_requirements, self.dimensions, simplify=False)
+        new_tiling = Tiling(
+            new_obstructions, new_requirements, self.dimensions, simplify=False
+        )
         return new_tiling
 
     # Construction methods


### PR DESCRIPTION
A method for unfusing a row or col that doesn't need the tiling to be simplified.
We do this pretty often, so having a method for it seemed usefull.

I also removed functions only used in old versions of our fusion methods.