### PR TITLE
Bug fix in removing redundant requirement lists?

### DIFF
--- a/gridded_cayley_permutations/simplify_obstructions_and_requirements.py
+++ b/gridded_cayley_permutations/simplify_obstructions_and_requirements.py
@@ -71,10 +71,15 @@ class SimplifyObstructionsAndRequirements:
         """Remove requirements lists that are implied by other requirements lists."""
         indices = []
         for i, req_list_1 in enumerate(self.requirements):
-            for j, req_list_2 in enumerate(self.requirements):
-                if i != j and j not in indices:
-                    if any(req.contains(req_list_2) for req in req_list_1):
-                        indices.append(i)
+            if all(
+                any(
+                    self.implied_by_requirement(req, req_list_2)
+                    for j, req_list_2 in enumerate(self.requirements)
+                    if i != j and j not in indices
+                )
+                for req in req_list_1
+            ):
+                indices.append(i)
         self.requirements = tuple(
             req for i, req in enumerate(self.requirements) if i not in indices
         )


### PR DESCRIPTION
I'm pretty sure there is a bug when removing redundant requirement lists in the SimplifyObstructionsAndRequirements class. Right now, it looks to me like a requirement list R is removed if some requirement in R completely contains a different requirement list R_0. This means if the requirements for a tiling are {{(012, ((0, 0), (0, 0)))}, {(01, ((0,0), (0,0)))}}, the first list would be removed and then the set of GriddedCayleyPerms contained in the tiling would get some extra patterns like (011, (0,0)). 

I think what should happen instead is that a requirements list R should be removed if for all requirements r in R, there exists some R_0 s.t. for every requirement r_0 in R_0, r is contained in r_0 (in other words, r is implied by R_0). 

Does this seem correct?